### PR TITLE
Prevent callback of taking picture when inPreview is false

### DIFF
--- a/camera/src/com/commonsware/cwac/camera/CameraView.java
+++ b/camera/src/com/commonsware/cwac/camera/CameraView.java
@@ -701,6 +701,10 @@ public class CameraView extends ViewGroup implements AutoFocusCallback {
 
     @Override
     public void onPictureTaken(byte[] data, Camera camera) {
+      if (!inPreview) {
+        return;
+      }
+      
       camera.setParameters(previewParams);
 
       if (data != null) {


### PR DESCRIPTION
In our app, we encounter 21 crashes in 15 users who taking photo and pausing the preview immediately.
This makes the callback "onPictureTaken" be invoked after the preview paused. 

The crash stacktrace:
```
java.lang.RuntimeException: setParameters failed
        at android.hardware.Camera.native_setParameters(Camera.java:-2)
        at android.hardware.Camera.setParameters(Camera.java:2689)
        at com.commonsware.cwac.camera.CameraView$PictureTransactionCallback.onPictureTaken(CameraView.java:704)
        at android.hardware.Camera$EventHandler.handleMessage(Camera.java:1572)
        at android.os.Handler.dispatchMessage(Handler.java:102)
        at android.os.Looper.loop(Looper.java:155)
        at android.app.ActivityThread.main(ActivityThread.java:5721)
        at java.lang.reflect.Method.invoke(Method.java:-2)
        at java.lang.reflect.Method.invoke(Method.java:372)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1029)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:824)
```
Or
```
java.lang.RuntimeException: Method called after release()
        at android.hardware.Camera.native_setParameters(Camera.java:-2)
        at android.hardware.Camera.setParameters(Camera.java:2261)
        at com.commonsware.cwac.camera.CameraView$PictureTransactionCallback.onPictureTaken(CameraView.java:704)
        at android.hardware.Camera$EventHandler.handleMessage(Camera.java:1304)
        at android.os.Handler.dispatchMessage(Handler.java:102)
        at android.os.Looper.loop(Looper.java:157)
        at android.app.ActivityThread.main(ActivityThread.java:5633)
        at java.lang.reflect.Method.invokeNative(Method.java:-2)
        at java.lang.reflect.Method.invoke(Method.java:515)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:896)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:712)
        at dalvik.system.NativeStart.main(NativeStart.java:-2)
```